### PR TITLE
Moving dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "author": "Anthony Kinsey",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "bluebird": "^3.3.1",
     "epochtalk-core-pg": "epochtalk/core-pg"
   }


### PR DESCRIPTION
Move dependencies to devDependencies, so the modules will look at the top level project for epochtalk-core-pg and bluebird. Any modules not in the base project can be included in regular dependencies.